### PR TITLE
Implement Scenarios for Query Param Changes

### DIFF
--- a/tests/dummy/app/controllers/feed.js
+++ b/tests/dummy/app/controllers/feed.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: ['filter', 'sort', 'direction'],
+  filter: null,
+  sort: null,
+  direction: null,
+
+  feedItems: Ember.computed('sort', 'direction', 'model', function() {
+    let field = this.get('sort');
+    let direction = this.get('direction');
+    let model = this.get('model');
+
+    return model.sort(function(a,b) {
+      if (direction === 'desc') {
+        return a[field] < b[field];
+      } else {
+        return a[field] > b[field];
+      }
+    });
+  })
+
+});

--- a/tests/dummy/app/routes/feed.js
+++ b/tests/dummy/app/routes/feed.js
@@ -21,22 +21,22 @@ const FeedItem = EmberObject.extend({
 const FeedItemsList = EmberObject.extend({
   feedItems: null,
   feedItemsSorting: [],
-  sortedFeedItems: sort('feedItems', 'feedItemsSorting'),
+  sortedFeedItems: sort('feedItems', 'feedItemsSorting')
 });
 
 export default Route.extend({
   queryParams: {
     title: {
       refreshModel: true,
-      replace: true,  // prevents an additional item from being added to browser history
+      replace: true // prevents an additional item from being added to browser history
     },
     type: {
       refreshModel: true,
-      replace: true,
+      replace: true
     },
     createdAt: {
       refreshModel: false,
-      replace: true,
+      replace: true
     }
   },
 

--- a/tests/dummy/app/routes/feed.js
+++ b/tests/dummy/app/routes/feed.js
@@ -3,6 +3,7 @@ import Ember from 'ember';
 const {
   Route,
   Object: EmberObject,
+  A,
   computed: { sort }
 } = Ember;
 
@@ -24,7 +25,6 @@ const FeedItemsList = EmberObject.extend({
 });
 
 export default Route.extend({
-
   queryParams: {
     title: {
       refreshModel: true,
@@ -35,36 +35,42 @@ export default Route.extend({
       replace: true,
     },
     createdAt: {
-      refreshModel: false,  
+      refreshModel: false,
       replace: true,
     }
   },
 
-  model({ title, type }) {
-    const feedItems = type ?
-      this._createFeedItems().filter(item => item.get('type').toLowerCase() === type.toLowerCase())
-      :
-      this._createFeedItems();
+  model({ title, type, createdAt }) {
+    const titleSorting = title ? `title:${title}` : '';
+    const createdAtSorting = createdAt ? `createdAt:${createdAt}` : '';
 
-    const feedItemsSorting = title ? `title:${title}` : '';
+    let feedItems = this._createFeedItems();
+    if (type) {
+      feedItems = feedItems.filter(item => item.get('type').toLowerCase() === type.toLowerCase());
+    }
 
     const feedItemsList = FeedItemsList.create({
-      feedItemsSorting: [feedItemsSorting],
+      feedItemsSorting: [createdAtSorting, titleSorting],
       feedItems
     });
-
     return feedItemsList.get('sortedFeedItems');
   },
 
-
-  _createFeedItems () {
+  /**
+   * Sample set of feed items -- no particular alphabetical sorting,
+   * but we'll start ordered by least-recently created so we can test
+   * updating query params to most-recently created
+   */
+  _createFeedItems() {
     const now = Date.now();
-    return [
-      FeedItem.create({ title: 'Nathan liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 1) }),
-      FeedItem.create({ title: 'Tomster sent you a private message.', type: 'Messages', createdAt: new Date(now - 10e7 * 2) }),
-      FeedItem.create({ title: 'Tomster liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 3) }),
+
+    return A([
+      FeedItem.create({ title: 'Nathan liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 10) }),
+      FeedItem.create({ title: 'Tomster sent you a private message.', type: 'Messages', createdAt: new Date(now - 10e7 * 8) }),
+      FeedItem.create({ title: 'Tomster liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 6) }),
       FeedItem.create({ title: 'Alice sent you a private message.', type: 'Messages', createdAt: new Date(now - 10e7 * 4) }),
-      FeedItem.create({ title: 'Tony Stark liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 5) })
-    ];
+      FeedItem.create({ title: 'Tony Stark liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 2) }),
+      FeedItem.create({ title: 'Zoey sent you a private message.', type: 'Messages', createdAt: new Date() })
+    ]);
   }
 });

--- a/tests/dummy/app/routes/feed.js
+++ b/tests/dummy/app/routes/feed.js
@@ -1,0 +1,70 @@
+import Ember from 'ember';
+
+const {
+  Route,
+  Object: EmberObject,
+  computed: { sort }
+} = Ember;
+
+const { computed } = Ember;
+
+const FeedItem = EmberObject.extend({
+  title: null,
+  type: null,
+  createdAt: null,
+  displayDate: computed('createdAt', function () {
+    return `${this.get('createdAt').toDateString()}`;
+  })
+});
+
+const FeedItemsList = EmberObject.extend({
+  feedItems: null,
+  feedItemsSorting: [],
+  sortedFeedItems: sort('feedItems', 'feedItemsSorting'),
+});
+
+export default Route.extend({
+
+  queryParams: {
+    title: {
+      refreshModel: true,
+      replace: true,  // prevents an additional item from being added to browser history
+    },
+    type: {
+      refreshModel: true,
+      replace: true,
+    },
+    createdAt: {
+      refreshModel: false,  
+      replace: true,
+    }
+  },
+
+  model({ title, type }) {
+    const feedItems = type ?
+      this._createFeedItems().filter(item => item.get('type').toLowerCase() === type.toLowerCase())
+      :
+      this._createFeedItems();
+
+    const feedItemsSorting = title ? `title:${title}` : '';
+
+    const feedItemsList = FeedItemsList.create({
+      feedItemsSorting: [feedItemsSorting],
+      feedItems
+    });
+
+    return feedItemsList.get('sortedFeedItems');
+  },
+
+
+  _createFeedItems () {
+    const now = Date.now();
+    return [
+      FeedItem.create({ title: 'Nathan liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 1) }),
+      FeedItem.create({ title: 'Tomster sent you a private message.', type: 'Messages', createdAt: new Date(now - 10e7 * 2) }),
+      FeedItem.create({ title: 'Tomster liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 3) }),
+      FeedItem.create({ title: 'Alice sent you a private message.', type: 'Messages', createdAt: new Date(now - 10e7 * 4) }),
+      FeedItem.create({ title: 'Tony Stark liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 5) })
+    ];
+  }
+});

--- a/tests/dummy/app/routes/feed.js
+++ b/tests/dummy/app/routes/feed.js
@@ -1,76 +1,46 @@
 import Ember from 'ember';
 
-const {
-  Route,
-  Object: EmberObject,
-  A,
-  computed: { sort }
-} = Ember;
-
-const { computed } = Ember;
-
-const FeedItem = EmberObject.extend({
+// Feed items have a backing class!
+const FeedItem = Ember.Object.extend({
   title: null,
   type: null,
   createdAt: null,
-  displayDate: computed('createdAt', function () {
+  displayDate: Ember.computed('createdAt', function () {
     return `${this.get('createdAt').toDateString()}`;
   })
 });
 
-const FeedItemsList = EmberObject.extend({
-  feedItems: null,
-  feedItemsSorting: [],
-  sortedFeedItems: sort('feedItems', 'feedItemsSorting')
-});
+// Builds a newsfeed.
+function createFeed(filter) {
+  const now = Date.now();
 
-export default Route.extend({
-  queryParams: {
-    title: {
-      refreshModel: true,
-      replace: true // prevents an additional item from being added to browser history
-    },
-    type: {
-      refreshModel: true,
-      replace: true
-    },
-    createdAt: {
-      refreshModel: false,
-      replace: true
-    }
-  },
+  let base = Ember.A([
+    FeedItem.create({ title: 'Nathan liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 10) }),
+    FeedItem.create({ title: 'Tomster sent you a private message.', type: 'Messages', createdAt: new Date(now - 10e7 * 8) }),
+    FeedItem.create({ title: 'Tomster liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 6) }),
+    FeedItem.create({ title: 'Alice sent you a private message.', type: 'Messages', createdAt: new Date(now - 10e7 * 4) }),
+    FeedItem.create({ title: 'Tony Stark liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 2) }),
+    FeedItem.create({ title: 'Zoey sent you a private message.', type: 'Messages', createdAt: new Date() })
+  ]);
 
-  model({ title, type, createdAt }) {
-    const titleSorting = title ? `title:${title}` : '';
-    const createdAtSorting = createdAt ? `createdAt:${createdAt}` : '';
-
-    let feedItems = this._createFeedItems();
-    if (type) {
-      feedItems = feedItems.filter(item => item.get('type').toLowerCase() === type.toLowerCase());
-    }
-
-    const feedItemsList = FeedItemsList.create({
-      feedItemsSorting: [createdAtSorting, titleSorting],
-      feedItems
+  if (filter) {
+    base = base.filter(function(item) {
+      return item.type.toLowerCase() === filter.toLowerCase();
     });
-    return feedItemsList.get('sortedFeedItems');
+  }
+
+  return base;
+}
+
+export default Ember.Route.extend({
+  queryParams: {
+    filter: { refreshModel: true },
+    sort: { refreshModel: false },
+    direction: { refreshModel: false }
   },
 
-  /**
-   * Sample set of feed items -- no particular alphabetical sorting,
-   * but we'll start ordered by least-recently created so we can test
-   * updating query params to most-recently created
-   */
-  _createFeedItems() {
-    const now = Date.now();
-
-    return A([
-      FeedItem.create({ title: 'Nathan liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 10) }),
-      FeedItem.create({ title: 'Tomster sent you a private message.', type: 'Messages', createdAt: new Date(now - 10e7 * 8) }),
-      FeedItem.create({ title: 'Tomster liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 6) }),
-      FeedItem.create({ title: 'Alice sent you a private message.', type: 'Messages', createdAt: new Date(now - 10e7 * 4) }),
-      FeedItem.create({ title: 'Tony Stark liked your post "Why A11y is Awesome".', type: 'Likes', createdAt: new Date(now - 10e7 * 2) }),
-      FeedItem.create({ title: 'Zoey sent you a private message.', type: 'Messages', createdAt: new Date() })
-    ]);
+  model({ filter }) {
+    return createFeed(filter);
   }
+
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -133,21 +133,21 @@
     {{github-issue title="Focus Ordering"}}
 
     <h3>Query Params</h3>
-    {{!-- <p>Scenarios to write:</p>
-    <ul>
-      <li>Refreshing model</li>
-      <li>Non-refreshing model</li>
-    </ul> --}}
     <ol>
       <li>Click the "Feed" link.</li>
       <li>Focus should be set to a block which begins with the "Feed" header.</li>
-      <li>{{#link-to 'feed' (query-params title="asc")}}Upate query params to sort items alphabetically (A-Z){{/link-to}}</li>
+      <li>{{#link-to 'feed' (query-params title="asc")}}Update query params to sort items alphabetically (A-Z){{/link-to}}</li>
       <li>Items should reorder accordingly</li>
       <li>Focus should be maintained on the block which begins with the "Feed" header.</li>
-      <li>{{#link-to 'feed' (query-params type="messages")}}Upate query params to filter on the <i>Messages</i> type{{/link-to}}</li>
-      <li>Only items with the type <i>Messages</i> should be shown.</li>
+      <li>{{#link-to 'feed' (query-params type="messages")}}Update query params to filter on the <i>Messages</i> type{{/link-to}}</li>
+      <li>Only <i>Messages</i> items should displayed -- and they should be sorted A-Z</li>
       <li>Focus should be maintained on the block which begins with the "Feed" header.</li>
-      <li><strong>TODO: Add scenario for changing a QP that doesn't refresh the model.</strong></li>
+      <li>{{#link-to 'feed' (query-params createdAt="desc")}}Update query params to sort by the most recent items{{/link-to}}</li>
+      <li>The URL should change, but the display shouldn't (<i>createdAt</i> is a non-model-refreshing query param)</li>
+      <li><button {{action "reload"}}>Hard Reload</button></li>
+      <li>The application should load correctly and begin reading at the top of the page.</li>
+      <li>No focus should have been set.</li>
+      <li>Only <i>Messages</i> items should displayed -- and they should be sorted by the most recent creation date.</li>
     </ol>
 
     <h3>Loading Routes</h3>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -158,6 +158,7 @@
       <li>The application should load correctly and begin reading at the top of the page.</li>
       <li>No focus should have been set.</li>
     </ol>
+    {{github-issue title="Query Params"}}
 
     <h3>Loading Routes</h3>
     <p>Scenarios to write:</p>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -133,21 +133,30 @@
     {{github-issue title="Focus Ordering"}}
 
     <h3>Query Params</h3>
+    <p>These tests are for focusing behavior. You may use your mouse to click through the links in this test.</p>
     <ol>
-      <li>Click the "Feed" link.</li>
+      <li><button {{action "resetDemo"}}>Reset Demo</button></li>
+      <li>{{#link-to "feed"}}Load the Feed route.{{/link-to}}</li>
       <li>Focus should be set to a block which begins with the "Feed" header.</li>
-      <li>{{#link-to 'feed' (query-params title="asc")}}Update query params to sort items alphabetically (A-Z){{/link-to}}</li>
-      <li>Items should reorder accordingly</li>
-      <li>Focus should be maintained on the block which begins with the "Feed" header.</li>
-      <li>{{#link-to 'feed' (query-params type="messages")}}Update query params to filter on the <i>Messages</i> type{{/link-to}}</li>
-      <li>Only <i>Messages</i> items should displayed -- and they should be sorted A-Z</li>
-      <li>Focus should be maintained on the block which begins with the "Feed" header.</li>
-      <li>{{#link-to 'feed' (query-params createdAt="desc")}}Update query params to sort by the most recent items{{/link-to}}</li>
-      <li>The URL should change, but the display shouldn't (<i>createdAt</i> is a non-model-refreshing query param)</li>
+
+      <li>{{#link-to "feed" (query-params sort="title")}}Update query params to sort by title.{{/link-to}}</li>
+      <li>Model was <em>not</em> refreshed; full transition <em>not</em> performed.</li>
+      <li>Items should reorder into alphabetical order.</li>
+      <li>No focus should be set.</li>
+
+      <li>{{#link-to "feed" (query-params filter="messages")}}Update query params to filter on the <em>Messages</em> type.{{/link-to}}</li>
+      <li>Model was refreshed; full transition performed.</li>
+      <li>Only <em>Messages</em> items should displayed.</li>
+      <li>Focus should be set to a block which begins with the "Feed" header.</li>
+
+      <li>{{#link-to "feed" (query-params sort="createdAt" direction="desc")}}Update query params to sort by date, newest to oldest.{{/link-to}}</li>
+      <li>Model was <em>not</em> refreshed; full transition <em>not</em> performed.</li>
+      <li>Items should reorder into reverse chronological order.</li>
+      <li>No focus should be set.</li>
+
       <li><button {{action "reload"}}>Hard Reload</button></li>
       <li>The application should load correctly and begin reading at the top of the page.</li>
       <li>No focus should have been set.</li>
-      <li>Only <i>Messages</i> items should displayed -- and they should be sorted by the most recent creation date.</li>
     </ol>
 
     <h3>Loading Routes</h3>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -133,11 +133,22 @@
     {{github-issue title="Focus Ordering"}}
 
     <h3>Query Params</h3>
-    <p>Scenarios to write:</p>
+    {{!-- <p>Scenarios to write:</p>
     <ul>
       <li>Refreshing model</li>
       <li>Non-refreshing model</li>
-    </ul>
+    </ul> --}}
+    <ol>
+      <li>Click the "Feed" link.</li>
+      <li>Focus should be set to a block which begins with the "Feed" header.</li>
+      <li>{{#link-to 'feed' (query-params title="asc")}}Upate query params to sort items alphabetically (A-Z){{/link-to}}</li>
+      <li>Items should reorder accordingly</li>
+      <li>Focus should be maintained on the block which begins with the "Feed" header.</li>
+      <li>{{#link-to 'feed' (query-params type="messages")}}Upate query params to filter on the <i>Messages</i> type{{/link-to}}</li>
+      <li>Only items with the type <i>Messages</i> should be shown.</li>
+      <li>Focus should be maintained on the block which begins with the "Feed" header.</li>
+      <li><strong>TODO: Add scenario for changing a QP that doesn't refresh the model.</strong></li>
+    </ol>
 
     <h3>Loading Routes</h3>
     <p>Scenarios to write:</p>

--- a/tests/dummy/app/templates/feed.hbs
+++ b/tests/dummy/app/templates/feed.hbs
@@ -1,6 +1,6 @@
 <h2>Feed</h2>
 <ul role="group">
-  {{#each model as |feedItem|}}
+  {{#each feedItems as |feedItem|}}
     <li>{{feedItem.title}} (Type: <i>{{feedItem.type}}</i>, Date: {{feedItem.displayDate}})</li>
   {{/each}}
 </ul>

--- a/tests/dummy/app/templates/feed.hbs
+++ b/tests/dummy/app/templates/feed.hbs
@@ -1,6 +1,6 @@
 <h2>Feed</h2>
 <ul role="group">
-  <li>This is a feed item.</li>
-  <li>This is a feed item.</li>
-  <li>This is a feed item.</li>
+  {{#each model as |feedItem|}}
+    <li>{{feedItem.title}} (Type: <i>{{feedItem.type}}</i>, Date: {{feedItem.displayDate}})</li>
+  {{/each}}
 </ul>


### PR DESCRIPTION
To test scenarios for query params, I've taken to having the `feed` route return a list of basic `FeedItems` (I didn't want to go all out with a set of `Model`s just yet) -- which can be sorted/filtered depending on the route's current query params. 

The steps that I have in mind:

- [x] Click on the `Feed` link.
- [x] Container for `feed` template should be focused.
- [x] Sort on title (model-refreshing QP).
- [x] Template should update and display items accordingly.
- [x] Container for `feed` template should be focused.
- [x] Filter down to type="Messages" (model-refreshing QP).
- [x] Template should update and display items accordingly.
- [x] Container for `feed` template should be focused.
- [x] Sort on most recently created (non-model-refreshing QP).
- [x] Template should update and display items accordingly.
- [x] Container for `feed` template should be focused.


- [ ] [Implement scenarios for nested query parameters](https://github.com/ember-a11y/ember-a11y/pull/22#issuecomment-223399876)