### PR TITLE
Provide a "Reset Demo" button for each scenario

### DIFF
--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -7,6 +7,10 @@ export default Ember.Route.extend({
     return { prefix };
   },
   actions: {
+    resetDemo() {
+      this.transitionTo('index').then(() => this.send('reload'));
+    },
+
     reload() {
       window.location.reload(true);
     }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -16,75 +16,74 @@
     <h1>Testing Procedure</h1>
     <p>Since there is no way to automate screen readers for testing, this is an interactive script to help you run all of the tests inside of each screen reader.</p>
 
-
-    <h2>Reset Procedure</h2>
-    <ol>
-      <li>{{#link-to 'index'}}Load the index route.{{/link-to}}</li>
-      <li><button {{action "reload"}}>Hard Reload</button></li>
-    </ol>
-
     <h2>Tests</h2>
-    <p>Each of these tests should be reviewed in every single OS/AT/Browser combination. Before each test follow the reset procedure above.</p>
+    <p>Each of these tests should be reviewed in every single OS/AT/Browser combination.</p>
 
     <h3>Deep Linking</h3>
     <p>These tests are for first-experience reading behavior. You may use your mouse to click through the links in these tests.</p>
 
     <h4>Generic Route</h4>
     <ol>
+      <li><button {{action "resetDemo"}}>Reset Demo</button></li>
       <li>{{#link-to 'messages.message' 'Jimmy'}}Visit messages.message as the first page of the application.{{/link-to}}</li>
       <li><button {{action "reload"}}>Hard Reload</button></li>
       <li>The application should load correctly and begin reading at the top of the page.</li>
       <li>No focus should have been set.</li>
     </ol>
-     
+
     {{github-issue 'Generic Route'}}
 
     <h4>Error, Sibling Error Route, Top Level</h4>
     <ol>
+      <li><button {{action "resetDemo"}}>Reset Demo</button></li>
       <li><a href="{{model.prefix}}boom">Visit boom as the first page of the application.</a></li>
       <li><button {{action "reload"}}>Hard Reload</button></li>
       <li>The application should load correctly and begin reading at the top of the page.</li>
       <li>Content should include "Global Error".</li>
       <li>No focus should have been set.</li>
     </ol>
-     
+
     {{github-issue 'Error, Sibling Error Route, Top Level'}}
 
     <h4>Error, Error Substate, Top Level</h4>
     <ol>
+      <li><button {{action "resetDemo"}}>Reset Demo</button></li>
       <li><a href="{{model.prefix}}boomsubstate">Visit boomsubstate as the first page of the application.</a></li>
       <li><button {{action "reload"}}>Hard Reload</button></li>
       <li>The application should load correctly and begin reading at the top of the page.</li>
       <li>Content should include "Boom Substate Error".</li>
       <li>No focus should have been set.</li>
     </ol>
-     
+
     {{github-issue 'Error, Error Substate, Top Level'}}
 
     <h4>Error, Sibling Error Route, Nested</h4>
     <ol>
+      <li><button {{action "resetDemo"}}>Reset Demo</button></li>
       <li><a href="{{model.prefix}}parent/boom">Visit parent.boom as the first page of the application.</a></li>
       <li><button {{action "reload"}}>Hard Reload</button></li>
       <li>The application should load correctly and begin reading at the top of the page.</li>
       <li>Content should include "Parent Error".</li>
       <li>No focus should have been set.</li>
     </ol>
-     
+
     {{github-issue 'Error, Sibling Error Route, Nested'}}
 
     <h4>Error, Error Substate, Nested</h4>
     <ol>
+      <li><button {{action "resetDemo"}}>Reset Demo</button></li>
       <li><a href="{{model.prefix}}parent/boomsubstate">Visit parent.boomsubstate as the first page of the application.</a></li>
       <li><button {{action "reload"}}>Hard Reload</button></li>
       <li>The application should load correctly and begin reading at the top of the page.</li>
       <li>Content should include "Boom Substate Error".</li>
       <li>No focus should have been set.</li>
     </ol>
-     
+
     {{github-issue 'Error, Error Substate, Nested'}}
 
     <h4>Error, Global Error Only, Nested</h4>
     <ol>
+      <li><button {{action "resetDemo"}}>Reset Demo</button></li>
       <li><a href="{{model.prefix}}iso-parent/boom">Visit iso-parent.boom as the first page of the application.</a></li>
       <li><button {{action "reload"}}>Hard Reload</button></li>
       <li>The application should load correctly and begin reading at the top of the page.</li>
@@ -98,7 +97,7 @@
 
     <h4>General</h4>
     <ol>
-      <li>Follow the reset procedure.</li>
+      <li><button {{action "resetDemo"}}>Reset Demo</button></li>
       <li>{{#link-to 'messages'}}Load the messages route.{{/link-to}}</li>
       <li>AT should begin reading the content, beginning with "Messages".</li>
       <li>{{#link-to 'feed'}}Load the feed route.{{/link-to}}</li>
@@ -110,13 +109,13 @@
     </ol>
 
 
-     
+
     {{github-issue 'Reading Behavior'}}
 
     <h3>Focus Ordering</h3>
     <p>This test is for focus ordering. You must complete this test using solely the assistive technology you're using. Complete these tasks only using previous and next navigation in your assistive tech. Do not use landmark navigation.</p>
     <ol>
-      <li>Follow the reset procedure.</li>
+      <li><button {{action "resetDemo"}}>Reset Demo</button></li>
       <li>Enter the content area.</li>
       <li>Click the "Feed" link.</li>
       <li>Focus should be set to a block which begins with the "Feed" header.</li>
@@ -141,7 +140,7 @@
     </ol>
 
 
-     
+
     {{github-issue 'Focus Ordering'}}
 
     <h3>Query Params</h3>


### PR DESCRIPTION
As the number of scenarios grows, I can't help but feel (partially from my own experience) that it’s far too easy for a user to forget following the go-to-index-and-reload step that we give them at the top. 

With that in mind, I had the idea of simply providing a "Reset Demo" button at the start of each scenario -- which would also remove the need for the standalone "Reset Procedure" section at the top.