### PR TITLE
improve focusing-outlet outline color and padding

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -45,7 +45,7 @@ ul > li {
 }
 
 .content {
-  padding: 0 10px;
+  padding: 0.5em 0.8em;
 }
 
 .hero-section {
@@ -102,8 +102,7 @@ h4, h5, h6 {
 
 
 .focusing-outlet:focus {
-  outline: yellow auto 5px;
-  outline: -webkit-focus-ring-color auto 5px;
+  outline: $theme-color__primary-1-dark auto 0.25em;
 }
 
 @import 'gh-fork-ribbon';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -12,7 +12,9 @@
       </nav>
     </section>
 
-    {{focusing-outlet}}
+    <section class="content">
+      {{focusing-outlet}}
+    </section>
   </div>
   <div class="column">
     <section class="content">


### PR DESCRIPTION
This PR addresses #31. 

Right now we're saying "use whatever outline color webkit gives us... or yellow":

```
 .focusing-outlet:focus {		
    outline: yellow auto 5px;		
    outline: -webkit-focus-ring-color auto 5px;		
 }
```
The change here make sure that we're controlling the color in all cases, that the color is in solid contrast with the background, and that the `focusing-outlet` is wrapped in a container with a small amount of padding so that the outline isn't occluded.