### PR TITLE
Ensure trees are processed properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,34 +51,35 @@ module.exports = {
     return this.isHTMLBars;
   },
 
-  treeForAddon: function() {
-    var tree = mergeTrees([this._super.treeForAddon.apply(this, arguments)], { overwrite: true });
-    var trees = [tree];
+  treeForAddon: function(_tree) {
+    var trees = [_tree];
 
     // include `ember-internals` module ONLY for htmlbars
     if (this.isHTMLBars) {
       trees.push(new Funnel(this.versionSpecificPath, {
-        files: ['ember-internals.js'],
-        destDir: 'modules/' + this.name
+        files: ['ember-internals.js']
       }));
     }
 
     trees.push(new Funnel(this.versionSpecificPath, {
-      files: ['ember-get-owner.js'],
-      destDir: 'modules/' + this.name
+      files: ['ember-get-owner.js']
     }));
 
-    return mergeTrees(trees, { overwrite: true });
+    var mergedTrees = mergeTrees(trees, { overwrite: true });
+
+    return this._super.treeForAddon.call(this, mergedTrees);
   },
 
-  treeForTemplates: function() {
-    var trees = [this._super.treeForTemplates.apply(this, arguments)];
+  treeForTemplates: function(_tree) {
+    var trees = [_tree];
 
     trees.push(this.treeGenerator(
       path.resolve(this.root, this.versionSpecificPath, 'app', 'templates')
     ));
 
-    return mergeTrees(trees.filter(Boolean), { overwrite: true });
+    var mergedTrees = mergeTrees(trees.filter(Boolean), { overwrite: true });
+
+    return this._super.treeForTemplates.call(this, mergedTrees);
   },
 
   treeForApp: function(defaultTree) {


### PR DESCRIPTION
This PR mirrors [PR to liquid-fire](https://github.com/ember-animation/liquid-fire/pull/528) to support proper tree processing. This means that we no longer rely on global ember cli es6 processing. Also `modules` prefix is no longer required (we shouldn't have done it in the first place as it is internal to CLI). More details can be found [here](https://github.com/ember-cli/ember-cli/pull/6530).

cc @rwjblue