### PR TITLE
Refocus element after substate is presented

### DIFF
--- a/addon/mixins/focusing.js
+++ b/addon/mixins/focusing.js
@@ -50,7 +50,12 @@ export default Mixin.create({
       window.addEventListener('scroll', handler);
 
       // Set the focus to the target outlet wrapper.
-      Ember.run.schedule('afterRender', this, function() { this.element.focus(); });
+      Ember.run.schedule('afterRender', this, function() {
+        this.element.blur();
+        Ember.run.next(this, function() {
+          this.element.focus();
+        });
+      });
     } else {
       this.element.removeAttribute('tabindex');
       this.element.removeAttribute('role');
@@ -85,7 +90,7 @@ export default Mixin.create({
       this.set('shouldFocus', shouldFocus);
 
       if (pivotHandler) {
-        application.set('_stashedHandlerInfos.pivotHandler.handled', handled || shouldFocus);
+        application.set('_stashedHandlerInfos.pivotHandler.handled', handled || (shouldFocus && !isChildState));
       }
 
       this.setFocus();

--- a/tests/acceptance/focus-test.js
+++ b/tests/acceptance/focus-test.js
@@ -98,7 +98,42 @@ test('Linking to descendant routes with local error states.', function(assert) {
   andThen(() => { assert.equal(checkFocus(), 'Global Error'); });
 });
 
-test('Should load leaf routes with a spurious focusing outlet without any errors.', function(assert) {
+test('Linking to a slow loading route', function(assert) {
+  visit('/');
+
+  let focusingOutlet;
+  let focusCount = 0;
+  let blurCount = 0;
+
+  andThen(() => {
+    focusingOutlet = document.querySelector('.focusing-outlet');
+
+    focusingOutlet.focusStub = focusingOutlet.focus;
+    focusingOutlet.focus = () => {
+      focusCount++;
+      focusingOutlet.focusStub();
+    };
+
+    focusingOutlet.blurStub = focusingOutlet.blur;
+    focusingOutlet.blur = () => {
+      blurCount++;
+      focusingOutlet.blurStub();
+    };
+  });
+
+  visit('/slow');
+
+  andThen(() => {
+    assert.equal(focusCount, 2);
+    assert.equal(blurCount, 2);
+    assert.equal(checkFocus(), 'Slow Route');
+
+    focusingOutlet.focus = focusingOutlet.focusStub;
+    focusingOutlet.blur = focusingOutlet.blurStub;
+  });
+});
+
+test('Should load leaf routes with a spurious focusing focusingOutlet without any errors.', function(assert) {
   visit('/');
   visit('/about');
   andThen(() => { assert.equal(checkFocus(), 'About Us'); });


### PR DESCRIPTION
This update attempts to address an issue I came across earlier this week.

When you navigate to a route which takes a while to load, prompting the loading substate, the addon would set the browser's focus on the outlet, which contained the loading message. This is good! However, I discovered two problems with this:

First, when the long request was resolved, `pivotHandler.handled` had already been set to `true` which would prevent the outlet from being focused again.

Second, even if the focus was triggered again, it wouldn't prompt AT to present the information  because that element was already focused from the loading substate.

My changes address both of these problems.

## Note
I had initially tried to just do `this.element.blur().focus();` but this didn't work (I'm assuming because it was all being done on the same event _tick_). However, wrapping the `focus` in an `Em.run.next` works wonders! I've tested this in Chrome and Safari without any problem and it presents much more better.