### PR TITLE
Only test with Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "4"
   - "6"
-  - "7"
 
 sudo: false
 
@@ -20,7 +18,6 @@ env:
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary
-  - EMBER_TRY_SCENARIO=ember-default
 
 matrix:
   fast_finish: true

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -91,12 +91,6 @@ module.exports = {
           'ember-source': null
         }
       }
-    },
-    {
-      name: 'ember-default',
-      npm: {
-        devDependencies: {}
-      }
     }
   ]
 };


### PR DESCRIPTION
This will speed up the build times a TON. I don't see much value in
testing many versions of node with a plugin that runs on the client
side.

Would close #57 