### PR TITLE
Prevent Uncaught TypeError: Cannot read property 'focus' of null`

### DIFF
--- a/addon/mixins/focusing.js
+++ b/addon/mixins/focusing.js
@@ -53,6 +53,7 @@ export default Mixin.create({
       Ember.run.schedule('afterRender', this, function() {
         this.element.blur();
         Ember.run.next(this, function() {
+          if (!this.element) { return; }
           this.element.focus();
         });
       });


### PR DESCRIPTION
This PR adds an early return in the setFocus method of the mixins/focusing.js to protect against the possibility of the focusing outlet being destroyed between the point that setFocus is called and the `run.next` executes and `this.element.focus()` is called