### PR TITLE
Fix `routeName` reference to private handler API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,12 +22,15 @@ env:
   matrix:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
+    - EMBER_TRY_SCENARIO=ember-1.10
     - EMBER_TRY_SCENARIO=ember-1.13
     - EMBER_TRY_SCENARIO=ember-lts-2.4
     - EMBER_TRY_SCENARIO=ember-lts-2.8
     - EMBER_TRY_SCENARIO=ember-lts-2.12
     - EMBER_TRY_SCENARIO=ember-lts-2.16
     - EMBER_TRY_SCENARIO=ember-lts-2.18
+    - EMBER_TRY_SCENARIO=ember-lts-3.4
+    - EMBER_TRY_SCENARIO=ember-lts-3.8
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta
     - EMBER_TRY_SCENARIO=ember-canary

--- a/addon/components/focusing-inner.js
+++ b/addon/components/focusing-inner.js
@@ -23,7 +23,9 @@ let FocusingInner = Ember.Component.extend({
     let outletState = this.get('outletState');
 
     let application = Ember.getOwner(this).lookup('application:main');
-    let pivotHandler = application.get('_stashedHandlerInfos.pivotHandler.handler.routeName');
+    let pivotHandler =
+      application.get('_stashedHandlerInfos.pivotHandler.handler.routeName') ||
+      application.get('_stashedHandlerInfos.pivotHandler.name');
 
     // Supports Handlebars version which stores information up one level.
     let outletObject = outletState.outlets || outletState;

--- a/addon/utils/pivot-route-identifier.js
+++ b/addon/utils/pivot-route-identifier.js
@@ -14,7 +14,14 @@ export default function pivotRouteIdentifier(oldHandlers, newHandlers) {
     let oldHandler = oldHandlers[i];
     let newHandler = newHandlers[i];
 
-    if (oldHandler.handler.routeName !== newHandler.handler.routeName) {
+    let oldRouteName =
+      (oldHandler.handler && oldHandler.handler.routeName) ||
+      oldHandler._route.routeName;
+    let newRouteName =
+      (newHandler.handler && newHandler.handler.routeName) ||
+      newHandler._route.routeName;
+
+    if (oldRouteName !== newRouteName) {
       return newHandler;
     }
   }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,6 +1,17 @@
 module.exports = {
   scenarios: [
     {
+      name: 'ember-1.10',
+      bower: {
+        dependencies: {
+          'ember': '~1.10.0'
+        },
+        resolutions: {
+          'ember': '~1.10.0'
+        }
+      }
+    },
+    {
       name: 'ember-1.13',
       bower: {
         dependencies: {
@@ -64,6 +75,22 @@ module.exports = {
       npm: {
         devDependencies: {
           'ember-source': '~2.18.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-3.4',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.4.0'
+        }
+      }
+    },
+    {
+      name: 'ember-lts-3.8',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.8.0'
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-ember": "^5.0.0",
     "eslint-plugin-node": "^5.2.1",
     "loader.js": "^4.2.3",
-    "sass": "^1.13.4"
+    "sass": "~1.13.4"
   },
   "engines": {
     "node": "^4.5 || 6.* || >= 7.*"


### PR DESCRIPTION
This is essentially PR #78 without the Ember upgrade.

Fixes #75  
Closes #78

This is a riff off #78 (thx @ryanlabouve). It takes the fix from there and does the bare minimum to get the tests to pass on Travis.

In this case, since this repo has no `package-lock.json`, tweaking the `sass` version from `^1.13.4` to `~1.13.4` was necessary to get tests to pass again.